### PR TITLE
fix: signupMemberのdata raceを修正

### DIFF
--- a/benchmarker/scenario/load.go
+++ b/benchmarker/scenario/load.go
@@ -201,7 +201,7 @@ func (s *Scenario) loadSignup(ctx context.Context, step *isucandar.BenchmarkStep
 
 		signupMember := func(member *model.Contestant, role string) func(context.Context) {
 			return func(ctx context.Context) {
-				_, _, err = BrowserAccess(ctx, member, "/signup")
+				_, _, err := BrowserAccess(ctx, member, "/signup")
 				if err != nil {
 					step.AddError(err)
 					return


### PR DESCRIPTION
外側のスコープのerrに対する書き込みが並列で走ってしまっているのでdata raceが発生している
関数の内側にerrを作ることで回避した

close #66 