### PR TITLE
Roll grpc_kit to fix regression

### DIFF
--- a/webapp/ruby/Gemfile.lock
+++ b/webapp/ruby/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://isucon10-public.s3.dualstack.ap-northeast-1.amazonaws.com/git/6MGgQp9lDmsK6G0CNa0DCOWHkOXID9-1davWxzKzI28/grpc_kit.git
-  revision: 6416112910c994db50885af736afa41d93bbbd56
+  revision: 371fccb1ae4dd4568dc3788155d93078bf95186c
   ref: blocking-recv-buffer
   specs:
     grpc_kit (0.3.9)


### PR DESCRIPTION
- There was a regression by a fix for inconsistent data error. Inbound
  messages were incorrectly dropped with StopIteration exception
  including unary RPC call.

Follow-up: #70 825acb3d2688a2f158a866077b610b0ad5ed10fc