### PR TITLE
ruby: Send notify_clarification_answered notification after transaction finishes

### DIFF
--- a/webapp/ruby/app.rb
+++ b/webapp/ruby/app.rb
@@ -555,6 +555,8 @@ module Xsuportal
 
       req = decode_request_pb
 
+      clar = nil
+      updated = nil
       clar_pb = nil
       Database.transaction do
         clar_before = db.xquery(
@@ -593,10 +595,10 @@ module Xsuportal
           clar[:team_id],
         ).first
 
-        notifier.notify_clarification_answered(clar, updated: was_answered && was_disclosed == clar[:disclosed])
-
         clar_pb = clarification_pb(clar, team)
+        updated = was_answered && was_disclosed == clar[:disclosed]
       end
+      notifier.notify_clarification_answered(clar, updated: updated)
 
       encode_response_pb(
         clarification: clar_pb


### PR DESCRIPTION
Resolve #86 
#107 と同様の対応を notify_clarification_answered にも入れます。

#107 に合わせてこうしたんですが、Web Push の送信だけでなく notifications テーブルへの insert もトランザクションを抜けた後でやる、という仕様でいいでしょうか?