### PR TITLE
Skip decoding request body of POST /api/logout

### DIFF
--- a/webapp/ruby/app.rb
+++ b/webapp/ruby/app.rb
@@ -1053,8 +1053,6 @@ module Xsuportal
     end
 
     post '/api/logout' do
-      req = decode_request_pb
-
       if session[:contestant_id]
         session.delete(:contestant_id)
       else

--- a/webapp/rust/src/contestant.rs
+++ b/webapp/rust/src/contestant.rs
@@ -49,10 +49,7 @@ pub async fn login(
     .into())
 }
 
-pub async fn logout(
-    session: Session,
-    _message: ProtoBuf<LogoutRequest>,
-) -> Result<HttpResponse, AWError> {
+pub async fn logout(session: Session) -> Result<HttpResponse, AWError> {
     if session.get::<String>("contestant_id")?.is_some() {
         session.remove("contestant_id");
         HttpResponse::Ok().protobuf(LogoutResponse {})


### PR DESCRIPTION
request body を使わないエンドポイントでは全体的にデコード自体をスキップしてそうなんですが、POST /api/logout だけそうなってないので揃えてみました。
POST /api/logout に変な pb が与えられたときの挙動が変わるので、スキップしていいか確認したいです。