### PR TITLE
rust: Unify error handling of mysql::FromRow

### DIFF
--- a/webapp/rust/src/contestant.rs
+++ b/webapp/rust/src/contestant.rs
@@ -338,18 +338,32 @@ pub struct Notification {
     pub updated_at: NaiveDateTime,
 }
 impl FromRow for Notification {
-    fn from_row_opt(row: mysql::Row) -> Result<Self, mysql::FromRowError> {
+    fn from_row_opt(mut row: mysql::Row) -> Result<Self, mysql::FromRowError> {
         Ok(Self {
-            id: row.get("id").expect("id column is missing"),
+            id: row
+                .take_opt("id")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
             contestant_id: row
-                .get("contestant_id")
-                .expect("contestant_id column is missing"),
-            read: row.get("read").expect("read column is missing"),
+                .take_opt("contestant_id")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            read: row
+                .take_opt("read")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
             encoded_message: row
-                .get("encoded_message")
-                .expect("encoded_message column is missing"),
-            created_at: row.get("created_at").expect("created_at column is missing"),
-            updated_at: row.get("updated_at").expect("updated_at column is missing"),
+                .take_opt("encoded_message")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            created_at: row
+                .take_opt("created_at")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            updated_at: row
+                .take_opt("updated_at")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
         })
     }
 }

--- a/webapp/rust/src/leaderboard.rs
+++ b/webapp/rust/src/leaderboard.rs
@@ -17,42 +17,57 @@ struct LeaderboardRow {
     finish_count: Option<i64>,
 }
 impl FromRow for LeaderboardRow {
-    fn from_row_opt(row: mysql::Row) -> Result<Self, mysql::FromRowError> {
-        fn convert(row: &mysql::Row) -> Result<LeaderboardRow, mysql::FromValueError> {
-            Ok(LeaderboardRow {
-                id: row.get_opt("id").expect("id column is missing")?,
-                name: row.get_opt("name").expect("name column is missing")?,
-                leader_id: row
-                    .get_opt("leader_id")
-                    .expect("leader_id column is missing")?,
-                withdrawn: row
-                    .get_opt("withdrawn")
-                    .expect("withdrawn column is missing")?,
-                student: row.get_opt("student").expect("student column is missing")?,
-                best_score: row
-                    .get_opt("best_score")
-                    .expect("best_score column is missing")?,
-                best_score_started_at: row
-                    .get_opt("best_score_started_at")
-                    .expect("best_score_started_at column is missing")?,
-                best_score_marked_at: row
-                    .get_opt("best_score_marked_at")
-                    .expect("best_score_marked_at column is missing")?,
-                latest_score: row
-                    .get_opt("latest_score")
-                    .expect("latest_score column is missing")?,
-                latest_score_started_at: row
-                    .get_opt("latest_score_started_at")
-                    .expect("latest_score_started_at column is missing")?,
-                latest_score_marked_at: row
-                    .get_opt("latest_score_marked_at")
-                    .expect("latest_score_marked_at column is missing")?,
-                finish_count: row
-                    .get_opt("finish_count")
-                    .expect("finish_count column is missing")?,
-            })
-        }
-        convert(&row).map_err(|_| mysql::FromRowError(row))
+    fn from_row_opt(mut row: mysql::Row) -> Result<Self, mysql::FromRowError> {
+        Ok(Self {
+            id: row
+                .take_opt("id")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            name: row
+                .take_opt("name")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            leader_id: row
+                .take_opt("leader_id")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            withdrawn: row
+                .take_opt("withdrawn")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            student: row
+                .get_opt("student")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            best_score: row
+                .take_opt("best_score")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            best_score_started_at: row
+                .take_opt("best_score_started_at")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            best_score_marked_at: row
+                .take_opt("best_score_marked_at")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            latest_score: row
+                .take_opt("latest_score")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            latest_score_started_at: row
+                .take_opt("latest_score_started_at")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            latest_score_marked_at: row
+                .take_opt("latest_score_marked_at")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            finish_count: row
+                .take_opt("finish_count")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+        })
     }
 }
 

--- a/webapp/rust/src/lib.rs
+++ b/webapp/rust/src/lib.rs
@@ -87,19 +87,37 @@ pub struct Team {
     pub created_at: NaiveDateTime,
 }
 impl FromRow for Team {
-    fn from_row_opt(row: mysql::Row) -> Result<Self, mysql::FromRowError> {
-        fn convert(row: &mysql::Row) -> Result<Team, ()> {
-            Ok(Team {
-                id: row.get("id").ok_or(())?,
-                name: row.get("name").ok_or(())?,
-                leader_id: row.get("leader_id").ok_or(())?,
-                email_address: row.get("email_address").ok_or(())?,
-                invite_token: row.get("invite_token").ok_or(())?,
-                withdrawn: row.get("withdrawn").ok_or(())?,
-                created_at: row.get("created_at").ok_or(())?,
-            })
-        }
-        convert(&row).map_err(|_| mysql::FromRowError(row))
+    fn from_row_opt(mut row: mysql::Row) -> Result<Self, mysql::FromRowError> {
+        Ok(Self {
+            id: row
+                .take_opt("id")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            name: row
+                .take_opt("name")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            leader_id: row
+                .take_opt("leader_id")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            email_address: row
+                .take_opt("email_address")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            invite_token: row
+                .take_opt("invite_token")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            withdrawn: row
+                .take_opt("withdrawn")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            created_at: row
+                .take_opt("created_at")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+        })
     }
 }
 
@@ -124,19 +142,37 @@ impl Contestant {
     }
 }
 impl FromRow for Contestant {
-    fn from_row_opt(row: mysql::Row) -> Result<Self, mysql::FromRowError> {
-        fn convert(row: &mysql::Row) -> Result<Contestant, ()> {
-            Ok(Contestant {
-                id: row.get("id").ok_or(())?,
-                password: row.get("password").ok_or(())?,
-                team_id: row.get("team_id").ok_or(())?,
-                name: row.get("name").ok_or(())?,
-                student: row.get("student").ok_or(())?,
-                staff: row.get("staff").ok_or(())?,
-                created_at: row.get("created_at").ok_or(())?,
-            })
-        }
-        convert(&row).map_err(|_| mysql::FromRowError(row))
+    fn from_row_opt(mut row: mysql::Row) -> Result<Self, mysql::FromRowError> {
+        Ok(Self {
+            id: row
+                .take_opt("id")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            password: row
+                .take_opt("password")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            team_id: row
+                .take_opt("team_id")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            name: row
+                .take_opt("name")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            student: row
+                .take_opt("student")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            staff: row
+                .take_opt("staff")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            created_at: row
+                .take_opt("created_at")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+        })
     }
 }
 
@@ -152,30 +188,41 @@ pub struct Clarification {
     pub updated_at: NaiveDateTime,
 }
 impl FromRow for Clarification {
-    fn from_row_opt(row: mysql::Row) -> Result<Self, mysql::FromRowError> {
-        fn convert(row: &mysql::Row) -> Result<Clarification, mysql::FromValueError> {
-            Ok(Clarification {
-                id: row.get_opt("id").expect("id column is missing")?,
-                team_id: row.get_opt("team_id").expect("team_id column is missing")?,
-                disclosed: row
-                    .get_opt("disclosed")
-                    .expect("disclosed column is missing")?,
-                question: row
-                    .get_opt("question")
-                    .expect("question column is missing")?,
-                answer: row.get_opt("answer").expect("answer column is missing")?,
-                answered_at: row
-                    .get_opt("answered_at")
-                    .expect("answered_at column is missing")?,
-                created_at: row
-                    .get_opt("created_at")
-                    .expect("created_at column is missing")?,
-                updated_at: row
-                    .get_opt("updated_at")
-                    .expect("updated_at column is missing")?,
-            })
-        }
-        convert(&row).map_err(|_| mysql::FromRowError(row))
+    fn from_row_opt(mut row: mysql::Row) -> Result<Self, mysql::FromRowError> {
+        Ok(Self {
+            id: row
+                .take_opt("id")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            team_id: row
+                .take_opt("team_id")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            disclosed: row
+                .take_opt("disclosed")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            question: row
+                .take_opt("question")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            answer: row
+                .take_opt("answer")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            answered_at: row
+                .take_opt("answered_at")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            created_at: row
+                .take_opt("created_at")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            updated_at: row
+                .take_opt("updated_at")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+        })
     }
 }
 
@@ -195,26 +242,56 @@ pub struct BenchmarkJob {
     pub updated_at: NaiveDateTime,
 }
 impl FromRow for BenchmarkJob {
-    fn from_row_opt(row: mysql::Row) -> Result<Self, mysql::FromRowError> {
+    fn from_row_opt(mut row: mysql::Row) -> Result<Self, mysql::FromRowError> {
         Ok(Self {
-            id: row.get("id").expect("id column is missing"),
-            team_id: row.get("team_id").expect("team_id column is missing"),
-            status: row.get("status").expect("status column is missing"),
+            id: row
+                .take_opt("id")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            team_id: row
+                .take_opt("team_id")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            status: row
+                .take_opt("status")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
             target_hostname: row
-                .get("target_hostname")
-                .expect("target_hostname column is missing"),
-            score_raw: row.get("score_raw").expect("score_raw column is missing"),
+                .take_opt("target_hostname")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            score_raw: row
+                .take_opt("score_raw")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
             score_deduction: row
-                .get("score_deduction")
-                .expect("score_deduction column is missing"),
-            reason: row.get("reason").expect("reason column is missing"),
-            passed: row.get("passed").expect("passed column is missing"),
-            started_at: row.get("started_at").expect("started_at column is missing"),
+                .take_opt("score_deduction")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            reason: row
+                .take_opt("reason")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            passed: row
+                .take_opt("passed")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            started_at: row
+                .take_opt("started_at")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
             finished_at: row
-                .get("finished_at")
-                .expect("finished_at column is missing"),
-            created_at: row.get("created_at").expect("created_at column is missing"),
-            updated_at: row.get("updated_at").expect("updated_at column is missing"),
+                .take_opt("finished_at")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            created_at: row
+                .take_opt("created_at")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            updated_at: row
+                .take_opt("updated_at")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
         })
     }
 }

--- a/webapp/rust/src/notifier.rs
+++ b/webapp/rust/src/notifier.rs
@@ -156,17 +156,36 @@ pub struct PushSubscription {
     pub updated_at: NaiveDateTime,
 }
 impl FromRow for PushSubscription {
-    fn from_row_opt(row: mysql::Row) -> Result<Self, mysql::FromRowError> {
+    fn from_row_opt(mut row: mysql::Row) -> Result<Self, mysql::FromRowError> {
         Ok(Self {
-            id: row.get("id").expect("id column is missing"),
+            id: row
+                .take_opt("id")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
             contestant_id: row
-                .get("contestant_id")
-                .expect("contestant_id column is missing"),
-            endpoint: row.get("endpoint").expect("endpoint column is missing"),
-            p256dh: row.get("p256dh").expect("p256dh column is missing"),
-            auth: row.get("auth").expect("auth column is missing"),
-            created_at: row.get("created_at").expect("created_at column is missing"),
-            updated_at: row.get("updated_at").expect("updated_at column is missing"),
+                .take_opt("contestant_id")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            endpoint: row
+                .take_opt("endpoint")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            p256dh: row
+                .take_opt("p256dh")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            auth: row
+                .take_opt("auth")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            created_at: row
+                .take_opt("created_at")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
+            updated_at: row
+                .take_opt("updated_at")
+                .ok_or_else(|| mysql::FromRowError(row.clone()))?
+                .map_err(|_| mysql::FromRowError(row.clone()))?,
         })
     }
 }


### PR DESCRIPTION
FromRow を実装するときのエラーハンドリングがバラバラだったのを統一。panic しないようにした。