### PR TITLE
webapp(Content-Type): give "proto=" only on errors

### DIFF
--- a/webapp/ruby/app.rb
+++ b/webapp/ruby/app.rb
@@ -419,7 +419,7 @@ module Xsuportal
 
       def encode_response_pb(payload={})
         cls = PB_TABLE.fetch(request.env.fetch('sinatra.route'))[1]
-        content_type "application/vnd.google.protobuf; proto=#{cls.descriptor.name}"
+        content_type "application/vnd.google.protobuf"
         cls.encode(cls.new(payload))
       end
 


### PR DESCRIPTION
https://github.com/isucon/isucon10-final/pull/67#issuecomment-694371740

this field is only used for determining xsuportal.proto.Error message,
and to ease implementing in other languages, we've decided to remove
(but had not been reflected this specification change yet.)