### PR TITLE
webapp/ruby(database): use init_command to set time_zone

### DIFF
--- a/webapp/ruby/lib/database.rb
+++ b/webapp/ruby/lib/database.rb
@@ -17,8 +17,8 @@ module Xsuportal
             cast_booleans: true,
             symbolize_keys: true,
             reconnect: true,
+            init_command: "SET time_zone='+00:00';",
           )
-          conn.query("SET time_zone='+00:00'")
           conn
         end
       end


### PR DESCRIPTION
This is the way to ensure the variables set, even in case of
reconnections.