### PR TITLE
ruby: Keep microsecond precision in POST /initialize

### DIFF
--- a/webapp/ruby/app.rb
+++ b/webapp/ruby/app.rb
@@ -467,10 +467,10 @@ module Xsuportal
             `contest_ends_at`
           ) VALUES (?, ?, ?, ?)
           SQL
-          Time.at(req.contest.registration_open_at.seconds).utc,
-          Time.at(req.contest.contest_starts_at.seconds).utc,
-          Time.at(req.contest.contest_freezes_at.seconds).utc,
-          Time.at(req.contest.contest_ends_at.seconds).utc,
+          Time.at(req.contest.registration_open_at.seconds, req.contest.registration_open_at.nanos / 1000, in: 'UTC'),
+          Time.at(req.contest.contest_starts_at.seconds, req.contest.contest_starts_at.nanos / 1000, in: 'UTC'),
+          Time.at(req.contest.contest_freezes_at.seconds, req.contest.contest_freezes_at.nanos / 1000, in: 'UTC'),
+          Time.at(req.contest.contest_ends_at.seconds, req.contest.contest_ends_at.nanos / 1000, in: 'UTC'),
         )
       else
         db.query(


### PR DESCRIPTION
#141 では (MySQL の datetime(6) に合わせて?) マイクロ秒に切り詰めて使っているので、POST /initialize でも同様に nanos を全部捨てずにマイクロ秒に切り詰めて使ったほうが一貫性がとれてるように思います。req.contest が与えられなかったときに使われる `NOW(6)` との一貫性もとれますし。