### PR TITLE
Add examples directory moved from webapp/ruby/debug

### DIFF
--- a/examples/Gemfile
+++ b/examples/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'mysql2'
+gem 'mysql2-cs-bind'
+gem 'grpc_kit', git: 'https://isucon10-public.s3.dualstack.ap-northeast-1.amazonaws.com/git/6MGgQp9lDmsK6G0CNa0DCOWHkOXID9-1davWxzKzI28/grpc_kit.git', ref: 'blocking-recv-buffer'
+gem 'webpush'

--- a/examples/Gemfile.lock
+++ b/examples/Gemfile.lock
@@ -1,0 +1,39 @@
+GIT
+  remote: https://isucon10-public.s3.dualstack.ap-northeast-1.amazonaws.com/git/6MGgQp9lDmsK6G0CNa0DCOWHkOXID9-1davWxzKzI28/grpc_kit.git
+  revision: 371fccb1ae4dd4568dc3788155d93078bf95186c
+  ref: blocking-recv-buffer
+  specs:
+    grpc_kit (0.3.9)
+      ds9 (>= 1.4.0)
+      google-protobuf (>= 3.7.0)
+      googleapis-common-protos-types (>= 1.0.2)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ds9 (1.4.1)
+      mini_portile2 (>= 2.2.0)
+    google-protobuf (3.13.0)
+    googleapis-common-protos-types (1.0.5)
+      google-protobuf (~> 3.11)
+    hkdf (0.3.0)
+    jwt (2.2.2)
+    mini_portile2 (2.5.0)
+    mysql2 (0.5.3)
+    mysql2-cs-bind (0.1.0)
+      mysql2
+    webpush (1.0.0)
+      hkdf (~> 0.2)
+      jwt (~> 2.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  grpc_kit!
+  mysql2
+  mysql2-cs-bind
+  webpush
+
+BUNDLED WITH
+   2.1.4

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,86 @@
+# Examples
+
+このディレクトリは、仮想ポータルおよび仮想ベンチマークサーバの動作確認に使えるスクリプトおよび、Web Push の実装の参考にできるコード例が置いてあります。
+
+| File                   | 説明                                                                    |
+| ---------------------- | ----------------------------------------------------------------------- |
+| `add_benchmark_job`    | 仮想ベンチマークジョブのエンキューを行えます。                          |
+| `finish_benchmark_job` | 仮想ベンチマークサーバから 1 件デキューし、仮想負荷走行を完了させます。 |
+| `show_notifications`   | `notifications` テーブルの中身をデコードして表示します。                |
+
+また、 `webpush` ディレクトリには、仮想ポータルに対して Web Push 通知でテストメッセージを送ることができる各言語のコードが置かれています。
+
+## セットアップ
+
+このディレクトリの `add_benchmark_job`, `finish_benchmark_job`, `show_notifications` は Ruby で実装されています。これらを実行するためには最初に
+
+```
+bundle install
+```
+
+を実行し、必要なライブラリをインストールしてください。
+
+## add_benchmark_job
+
+benchmark_jobs テーブルにレコードを追加します。 仮想ポータルの Enqueue ボタンを押した時と同様の動作が期待できます。
+
+```
+$ bundle exec ./add_benchmark_job -t team_id -h hostname -s status
+```
+
+- `-t team_id` エンキューをするチーム ID（必須）
+- `-h hostname` 仮想ベンチマークを実行するホスト名（default: `xsu-001`）
+  - これは名前解決ができる必要はなく、どのような文字列でも構いません
+- `-s status` エンキュー時の `benchmark_job` のステータスを整数で指定します。（default: `0`）
+  - PENDING = 0 (default)
+  - SENT = 1
+  - RUNNING = 2
+  - ERRORED = 3
+  - CANCELLED = 4
+  - FINISHED = 5
+
+## finish_benchmark_job
+
+仮想ベンチマークサーバ（gRPC）に接続してデキューをし、ランダムなスコアを生成して実行結果のレポートを登録します。仮想ベンチマーカーの挙動を模しています。
+
+```
+$ bundle exec ./finish_benchmark_job -t team_id
+```
+
+- `-t team_id` エンキューをするチーム ID（必須）
+
+## show_notifications
+
+notifications テーブルから指定された contestant 宛てのレコードをすべて取り出し、メッセージをデコードしたうえで標準出力に JSON 形式で出力します。
+
+```
+$ bundle exec ./show_notifications -c contestant_id
+```
+
+- `-c contestant_id` 通知を表示をする contestant の ID（必須）
+
+## webpush ディレクトリについて
+
+`webpush` ディレクトリには、仮想ポータルに対して Web Push 通知でテストメッセージを送ることができる各言語のコードが置かれています。
+
+これらのサンプルコードは、 `xsuportal.proto.resources.Notification.TestMessage` をメッセージとして持つ通知を生成し、指定された contestant の持つ push_subscriptions に対し Web Push で送ります。
+
+### セットアップ
+
+1. `webapp/generate_vapid_key.sh` を実行し、 `webapp/vapid_private.pem` を生成する
+2. 仮想ポータルにブラウザでアクセスして通知を受け取りたい contestant としてログインし、`/contestant/dashboard` から通知を購読する
+3. `webpush/ruby/send_web_push.rb`（Ruby の場合）を実行し、通知を送信する
+
+正常に Web Push が送信できた場合、下図のような通知を受け取ることができます。
+
+![image](https://user-images.githubusercontent.com/20384/94367612-d8064880-011a-11eb-8b21-495b1824de91.png)
+
+### Ruby 実装: webpush/ruby/send_web_push.rb
+
+```
+$ webpush/ruby/send_web_push.rb -c contestant_id -i vapid_private_key_path
+```
+
+- `-c contestant_id` 通知を送信する contestant の ID（必須）
+- `-i vapid_private_key_path` ECDSA with SHA-256 秘密鍵のパス（必須）
+  - `generate_vapid_key.sh` で生成した鍵を利用できます。

--- a/examples/add_benchmark_job
+++ b/examples/add_benchmark_job
@@ -1,7 +1,23 @@
 #!/usr/bin/env ruby
-$: << File.expand_path('../lib', __dir__)
 require 'optparse'
-require 'database'
+require 'mysql2'
+require 'mysql2-cs-bind'
+
+def db
+  @db ||= Mysql2::Client.new(
+    host: ENV['MYSQL_HOSTNAME'] || '127.0.0.1',
+    port: ENV['MYSQL_PORT'] || '3306',
+    username: ENV['MYSQL_USER'] || 'isucon',
+    database: ENV['MYSQL_DATABASE'] || 'xsuportal',
+    password: ENV['MYSQL_PASS'] || 'isucon',
+    charset: 'utf8mb4',
+    database_timezone: :utc,
+    cast_booleans: true,
+    symbolize_keys: true,
+    reconnect: true,
+    init_command: "SET time_zone='+00:00';",
+  )
+end
 
 team_id = nil
 status = 0
@@ -18,7 +34,6 @@ unless team_id && status
   abort option_parser.banner
 end
 
-db = Xsuportal::Database.connection
 db.xquery(
   'INSERT INTO `benchmark_jobs` (`team_id`, `status`, `target_hostname`, `updated_at`, `created_at`) VALUES (?, ?, ?, NOW(6), NOW(6))',
   team_id,

--- a/examples/finish_benchmark_job
+++ b/examples/finish_benchmark_job
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
-$: << File.expand_path('../lib', __dir__)
 require 'optparse'
 require 'socket'
+
+$: << File.expand_path('../webapp/ruby/lib', __dir__)
 require 'xsuportal/services/bench/receiving_pb'
 require 'xsuportal/services/bench/reporting_pb'
 require 'xsuportal/services/bench/receiving_services_pb'

--- a/examples/show_notifications
+++ b/examples/show_notifications
@@ -1,9 +1,27 @@
 #!/usr/bin/env ruby
-$: << File.expand_path('../lib', __dir__)
 require 'optparse'
-require 'xsuportal/resources/notification_pb'
-require 'database'
 require 'json'
+require 'mysql2'
+require 'mysql2-cs-bind'
+
+$: << File.expand_path('../webapp/ruby/lib', __dir__)
+require 'xsuportal/resources/notification_pb'
+
+def db
+  @db ||= Mysql2::Client.new(
+    host: ENV['MYSQL_HOSTNAME'] || '127.0.0.1',
+    port: ENV['MYSQL_PORT'] || '3306',
+    username: ENV['MYSQL_USER'] || 'isucon',
+    database: ENV['MYSQL_DATABASE'] || 'xsuportal',
+    password: ENV['MYSQL_PASS'] || 'isucon',
+    charset: 'utf8mb4',
+    database_timezone: :utc,
+    cast_booleans: true,
+    symbolize_keys: true,
+    reconnect: true,
+    init_command: "SET time_zone='+00:00';",
+  )
+end
 
 contestant_id = nil
 option_parser = OptionParser.new do |opt|
@@ -14,7 +32,6 @@ option_parser.parse!
 
 abort option_parser.banner unless contestant_id
 
-db = Xsuportal::Database.connection
 notifications = db.xquery(
   'SELECT * FROM `notifications` WHERE `contestant_id` = ? ORDER BY `id`',
   contestant_id,

--- a/examples/webpush/generate_vapid_key.sh
+++ b/examples/webpush/generate_vapid_key.sh
@@ -1,0 +1,1 @@
+../../webapp/generate_vapid_key.sh


### PR DESCRIPTION
Solves #114 

* add_benchmark_job.rb, finish_benchmark_job.rb, show_notifications.rb の3つを webapp/ruby/debug から examples/ に移動した。（拡張子の .rb も外した）
  * これらは Ruby 実装のみを残す。
* send_web_push.rb は webapp/ruby/debug から examples/webpush/ruby/ に移動した
  * これはWeb Push ライブラリおよび notification, push_subscriptions テーブルの使い方説明を兼ねるので、各言語移植者に移植をお願いしたい
