### PR TITLE
Implement no-clar mode

### DIFF
--- a/benchmarker/main.go
+++ b/benchmarker/main.go
@@ -64,6 +64,7 @@ var (
 	useTLS             bool
 	exitStatusOnFail   bool
 	noLoad             bool
+	noClar             bool
 
 	reporter benchrun.Reporter
 )
@@ -88,6 +89,7 @@ func init() {
 	flag.BoolVar(&useTLS, "tls", false, "server is a tls (HTTPS & gRPC over h2)")
 	flag.BoolVar(&exitStatusOnFail, "exit-status", false, "set exit status non-zero when a benchmark result is failing")
 	flag.BoolVar(&noLoad, "no-load", false, "exit on finished prepare")
+	flag.BoolVar(&noClar, "no-clar", false, "off sending clar")
 
 	timeoutDuration := ""
 	flag.StringVar(&timeoutDuration, "timeout", "10s", "request timeout duration")
@@ -261,6 +263,7 @@ func main() {
 	s.UseTLS = useTLS
 	s.PushService = pushService
 	s.NoLoad = noLoad
+	s.NoClar = noClar
 
 	b, err := isucandar.NewBenchmark(isucandar.WithLoadTimeout(65 * time.Second))
 	if err != nil {

--- a/benchmarker/scenario/load.go
+++ b/benchmarker/scenario/load.go
@@ -469,7 +469,7 @@ func (s *Scenario) loadClarification(ctx context.Context, step *isucandar.Benchm
 	w, err := worker.NewWorker(func(ctx context.Context, index int) {
 		team := s.Contest.Teams[index]
 		// Clar をまったく送信しないチームは早期脱落
-		if team.NonClarification {
+		if team.NonClarification || s.NoClar {
 			return
 		}
 

--- a/benchmarker/scenario/scenario.go
+++ b/benchmarker/scenario/scenario.go
@@ -25,6 +25,7 @@ type Scenario struct {
 	Contest      *model.Contest
 	TeamCapacity int32
 	NoLoad       bool
+	NoClar       bool
 
 	bpubsub  *pubsub.PubSub
 	rpubsub  *pubsub.PubSub


### PR DESCRIPTION
Clar の追加を行わないモードの実装。

ただ、手元で実行する限りだとあんまり効果がない。

```
no-clar

Count:
  enqueue-benchmark: 273
  list-notifications: 3077
  get-dashboard: 382
  finish-benchmark: 263
  push-notifications: 808
  audience-get-dashboard: 1984
  create-team: 10
  admin-get-clarifications: 110
  join-member: 20
(3394 * 1.0) + 198 - 150(err: 1, timeout: 161)
Pass: true / score: 3442 (3592 - 150)

with-clar

Count:
  admin-get-clarifications: 72
  audience-get-dashboard: 1962
  get-clarification: 75
  admin-answer-clarification: 74
  list-notifications: 3380
  create-team: 10
  enqueue-benchmark: 226
  get-dashboard: 435
  join-member: 20
  push-notifications: 969
  finish-benchmark: 222
  admin-get-clarification: 74
  post-clarification: 74
  resolve-clarification: 69
(3780 * 1.0) + 196 - 250(err: 3, timeout: 139)
Pass: true / score: 3726 (3976 - 250)
```