### PR TITLE
benchmarker: CreateTeamActionのエラーから処理するように変更

### DIFF
--- a/benchmarker/scenario/load.go
+++ b/benchmarker/scenario/load.go
@@ -203,13 +203,12 @@ func (s *Scenario) loadSignup(parent context.Context, step *isucandar.BenchmarkS
 		}
 
 		createTeam, chres, err := CreateTeamAction(ctx, team, lead)
-		if chres.StatusCode == 403 {
-			atomic.StoreUint32(&stopSignup, 1)
-			return
-		}
-
 		if err != nil {
 			step.AddError(err)
+			return
+		}
+		if chres.StatusCode == 403 {
+			atomic.StoreUint32(&stopSignup, 1)
 			return
 		}
 


### PR DESCRIPTION
```
22:15:55.908648 ISUCON10 benchmarker 9a15c0f+dirty
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x969d92]

goroutine 875 [running]:
github.com/isucon/isucon10-final/benchmarker/scenario.(*Scenario).loadSignup.func1(0xb7e9c0, 0xc00007a3c0, 0xffffffffffffffff)
	/home/sorah/git/github.com/isucon/isucon10-final/benchmarker/scenario/load.go:206 +0x3d2
github.com/isucon/isucandar/worker.(*Worker).processInfinity.func1(0xb7e9c0, 0xc00007a3c0)
	/home/sorah/.gopath/pkg/mod/github.com/isucon/isucandar@v0.0.0-20200929092117-706389954e6f/worker/worker.go:72 +0x46
github.com/isucon/isucandar/parallel.(*Parallel).Do.func1(0xc00003e900, 0xc000238660, 0xc000674cc0)
	/home/sorah/.gopath/pkg/mod/github.com/isucon/isucandar@v0.0.0-20200929092117-706389954e6f/parallel/parallel.go:68 +0x73
created by github.com/isucon/isucandar/parallel.(*Parallel).Do
	/home/sorah/.gopath/pkg/mod/github.com/isucon/isucandar@v0.0.0-20200929092117-706389954e6f/parallel/parallel.go:66 +0xa5
```
SEGVが発生していたので修正