### PR TITLE
Do not race detection on default build

### DIFF
--- a/benchmarker/Makefile
+++ b/benchmarker/Makefile
@@ -2,7 +2,7 @@ COMMIT=$(shell git rev-parse --short HEAD)
 DIRTY=$(shell git diff --quiet || echo '+dirty')
 
 GOTIMEOUT?=20s
-GOARGS?=-race
+GOARGS?=
 GOMAXPROCS?=$(shell nproc)
 GOPRIVATE="github.com/isucon"
 GOLDFLAGS=-X main.COMMIT=$(COMMIT)$(DIRTY)


### PR DESCRIPTION
本番ベンチ時に race detection で無駄に CPU つかうのもなんだなと思ったので