### PR TITLE
rust: Show gRPC request logs

### DIFF
--- a/webapp/rust/src/bench.rs
+++ b/webapp/rust/src/bench.rs
@@ -27,8 +27,9 @@ fn mysql_error_to_tonic_status(e: mysql::Error) -> TonicStatus {
 impl BenchmarkQueue for QueueService {
     async fn receive_benchmark_job(
         &self,
-        _request: Request<ReceiveBenchmarkJobRequest>,
+        request: Request<ReceiveBenchmarkJobRequest>,
     ) -> Result<Response<ReceiveBenchmarkJobResponse>, TonicStatus> {
+        log::info!("BenchmarkQueue: receive_benchmark_job: {:?}", request);
         let mut conn = self
             .db
             .get()
@@ -121,6 +122,7 @@ impl BenchmarkReport for ReportService {
         &self,
         request: Request<Streaming<ReportBenchmarkResultRequest>>,
     ) -> Result<Response<Self::ReportBenchmarkResultStream>, TonicStatus> {
+        log::info!("BenchmarkReport: report_benchmark_result: {:?}", request);
         let mut conn = self
             .db
             .get()

--- a/webapp/rust/src/bin/benchmark_server.rs
+++ b/webapp/rust/src/bin/benchmark_server.rs
@@ -1,8 +1,12 @@
 use listenfd::ListenFd;
+use std::env;
 use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    if env::var("RUST_LOG").is_err() {
+        env::set_var("RUST_LOG", "xsuportal=info");
+    }
     env_logger::init();
 
     let mysql_connection_env = xsuportal::MySQLConnectionEnv::default();


### PR DESCRIPTION
デフォルトっぽいロガーが無さそうなので log::info! で雑に出しておく……