### PR TITLE
nodejs: Fix invitation flow

### DIFF
--- a/webapp/nodejs/src/app.ts
+++ b/webapp/nodejs/src/app.ts
@@ -836,7 +836,7 @@ app.get("/api/registration/session", async (req, res, next) => {
 
     const response = new GetRegistrationSessionResponse();
     if (team) {
-      const teamResource = await getTeamResource(team, db, currentContestant.id == currentTeam.leader_id, true, false);
+      const teamResource = await getTeamResource(team, db, currentContestant?.id == currentTeam?.leader_id, true, false);
       response.setTeam(teamResource);
       response.setMemberInviteUrl(`/registration?team_id=${team.id}&invite_token=${team.invite_token}`);
       response.setInviteToken(team.invite_token);


### PR DESCRIPTION
in ruby:

```ruby
team: team ? team_pb(team, detail: current_contestant&.fetch(:id) == current_team&.fetch(:leader_id), enable_members: true) : nil,
```

in golang:

```golang
res.Team, err = makeTeamPB(db, team, contestant != nil && currentTeam != nil && contestant.ID == currentTeam.LeaderID.String, true)
```

in rust:

```rust
let detail = current_contestant.as_ref().map(|c| &c.id) == current_team.as_ref().and_then(|t| t.leader_id.as_ref());
Some(crate::build_team_pb(conn.deref_mut(), team.clone(), detail)?)
```

### TypeError: Cannot read property 'leader_id' of undefined

1. User A: Generate an invitation URL
2. User B: Login
3. User B: Jump to the invitation URL

### TypeError: Cannot read property 'id' of null

1. User A: Generate an invitation URL
2. User B (not logged in): Jump to the invitation URL
